### PR TITLE
Fix RecipeDetail URL crash and add preview sample

### DIFF
--- a/Recipes/Recipe.swift
+++ b/Recipes/Recipe.swift
@@ -27,9 +27,19 @@ struct Recipe: Codable, Identifiable {
     }
 }
 
-//extension Recipe {
-//    static let sample = Recipe(cuisine: "Italian", name: "Chicken Parmesan", photo_url_large: "", photo_url_small: "", source_url: "Please provide a source URL", id: UUID().uuidString, youtube_url: "Please provide a YouTube URL")
-//}
+
+extension Recipe {
+    /// Convenience sample data used for SwiftUI previews.
+    static let sample = Recipe(
+        cuisine: "Italian",
+        name: "Chicken Parmesan",
+        photo_url_large: "https://example.com/large.jpg",
+        photo_url_small: "https://example.com/small.jpg",
+        source_url: "https://example.com",
+        id: UUID().uuidString,
+        youtube_url: "https://youtube.com/watch?v=1234"
+    )
+}
 
 struct RecipesJSONResponse: Codable {
     let recipes: [Recipe]

--- a/Recipes/RecipeDetail.swift
+++ b/Recipes/RecipeDetail.swift
@@ -22,13 +22,15 @@ struct RecipeDetail: View {
             }
             .frame(width: 350, height: 350)
             HStack {
-                if recipe.source_url != nil {
-                    Link("Source", destination: URL(string: recipe.source_url!)!)
+                if let source = recipe.source_url,
+                   let url = URL(string: source) {
+                    Link("Source", destination: url)
                         .buttonStyle(.borderedProminent)
                         .padding()
                 }
-                if recipe.youtube_url != nil {
-                    Link("YouTube", destination: URL(string: recipe.youtube_url!)!)
+                if let youtube = recipe.youtube_url,
+                   let url = URL(string: youtube) {
+                    Link("YouTube", destination: url)
                         .buttonStyle(.borderedProminent)
                         .padding()
                 }
@@ -39,4 +41,5 @@ struct RecipeDetail: View {
 }
 
 #Preview {
+    RecipeDetail(recipe: .sample)
 }


### PR DESCRIPTION
## Summary
- avoid force-unwrapping optional URLs in `RecipeDetail`
- provide sample `Recipe` data for SwiftUI previews
- update `RecipeDetail` preview to use sample data

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_683f3a7701188332a6825a4a65856566